### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.5](https://github.com/wst7/tam/compare/v0.1.4...v0.1.5) - 2025-01-09
+
+### Other
+
+- config release-plz
+- config release
+- config release
+- config release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "tam"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tam"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["wst7 <wstreet7@outlook.com>"]
 description = "A tasks manager cli tool"


### PR DESCRIPTION
## 🤖 New release
* `tam`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/wst7/tam/compare/v0.1.4...v0.1.5) - 2025-01-09

### Other

- config release-plz
- config release
- config release
- config release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).